### PR TITLE
fix: reset tokeniser on edit

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -105,6 +105,8 @@ function Doc:on_text_change(type)
 		print('change', type)
 		self.wholeDoc = table.concat(self.lines, '')
 		self.ts.tree = self.ts.parser:parse_string(self.wholeDoc)
+
+		self.highlighter:soft_reset()
 	end
 end
 


### PR DESCRIPTION
Unlike LXL's default highlighter, TS parsers may update nodes both before and after the location the edit took place. This fix works by invalidating all lines in the highlighter upon an edit, forcing every line to be re-tokenised.

This is intended to just be a temporary measure. I suspect that the performance would be subpar (not like the code is optimised to begin with but you get the point). It might be worth optimising when we no longer discard and re-parse on every edit.