### PR TITLE
fix: rewrite tokenisation

### DIFF
--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -216,7 +216,7 @@
 (preproc_function_def
   name: (identifier) @function.macro)
 
-(comment) @comment @spell
+(comment) @comment
 
 ((comment) @comment.documentation
   (#lua-match? @comment.documentation "^/[*][*][^*].*[*]/$"))

--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -216,7 +216,7 @@
 (preproc_function_def
   name: (identifier) @function.macro)
 
-(comment) @comment @spell
+(comment) @comment
 
 ((comment) @comment.documentation
   (#lua-match? @comment.documentation "^/[*][*][^*].*[*]/$"))

--- a/queries/go/highlights.scm
+++ b/queries/go/highlights.scm
@@ -223,7 +223,7 @@
 
 ; Comments
 
-(comment) @comment @spell
+(comment) @comment
 
 ;; Doc Comments
 


### PR DESCRIPTION
Full rewrite of the algorithm used to parse nodes into tokens. Also removed the bogus `@spell` capture that does nothing except cause comments to be wrongly highlighted. We do not need it – it is Neovim-specific and is used for spellcheck.

Fixes #32. Fixes #33. Fixes #42.