### PR TITLE
fix: incremental highlighting

### DIFF
--- a/highlights.lua
+++ b/highlights.lua
@@ -4,8 +4,8 @@ local languages = require 'plugins.evergreen.languages'
 local M = {}
 
 local function localPath()
-   local str = debug.getinfo(2, 'S').source:sub(2)
-   return str:match '(.*[/\\])'
+	local str = debug.getinfo(2, 'S').source:sub(2)
+	return str:match '(.*[/\\])'
 end
 
 function M.query(ftype)
@@ -22,6 +22,26 @@ end
 
 --- @param doc core.doc
 function M.init(doc)
+	local function getSource(n)
+		local startPt = n:start_point()
+		local endPt   = n:end_point()
+		local startRow, startCol = startPt.row + 1, startPt.column + 1
+		local endRow, endCol     = endPt.row + 1, endPt.column
+
+		if startRow == endRow then
+			return doc.lines[startRow]:sub(startCol, endCol)
+		end
+
+		local lns = {}
+		lns[1] = doc.lines[startRow]:sub(startCol)
+		for i = startRow + 1, endRow - 1 do
+			lns[#lns + 1] = doc.lines[i]
+		end
+		lns[#lns + 1] = doc.lines[endRow]:sub(1, endCol)
+
+		return table.concat(lns)
+	end
+
 	if not doc.filename then return end
 
 	local p = parser.get(languages.fromDoc(doc))
@@ -32,27 +52,27 @@ function M.init(doc)
 			tree = p:parse_with(parser.input(doc.lines)),
 			query = p:query(M.query(languages.fromDoc(doc))):with {
 				['any-of?'] = function(t, ...)
-					local src = t:source()
+					local src = getSource(t)
 					for _, match in ipairs {...} do
 						if src == match then return true end
 					end
 					return false
 				end,
 				['lua-match?'] = function(t, pattern)
-					local src = t:source()
+					local src = getSource(t)
 					local res = string.match(src, pattern)
 					return res ~= nil
 				end,
 				['contains?'] = function(t, search)
 					local n = t
-					local res = string.find(n:source(), search)
+					local res = string.find(getSource(n), search)
 					if res then return true end
 
 					while not done do
 						n = n:prev_named_sibling()
 						if not n then break end
 
-						local res = string.find(n:source(), search)
+						local res = string.find(getSource(n), search)
 						if res then
 							return true
 						end

--- a/init.lua
+++ b/init.lua
@@ -83,21 +83,11 @@ function Doc:new(filename, abs_filename, new_file)
 	highlights.init(self)
 end
 
-function table.slice(tbl, first, last, step)
-	local sliced = {}
-
-	for i = first or 1, last or #tbl, step or 1 do
-		sliced[#sliced+1] = tbl[i]
-	end
-
-	return sliced
-end
-
-local function accumulateLen(tbl)
+local function accumulateLen(tbl, s, e)
 	local len = 0
 
-	for _, entry in ipairs(tbl) do
-		len = len + entry:len()
+	for i=s,e do
+		len = len + tbl[i]:len()
 	end
 
 	return len
@@ -122,10 +112,7 @@ function Doc:raw_insert(line, col, text, undo, time)
 	if self.treesit then
 		line, col = self:sanitize_position(line, col)
 
-		local lns = table.slice(self.lines, 1, line - 1)
-		local start = accumulateLen(lns)
-
-		local tsByte = start + col - 1
+		local tsByte = accumulateLen(self.lines, 1, line - 1) + col - 1
 		local tsLine, tsCol = line - 1, col - 1
 
 		self.ts.tree:edit_s {
@@ -157,10 +144,7 @@ function Doc:raw_remove(line1, col1, line2, col2, undo, time)
 
 		oldDocRemove(self, line1, col1, line2, col2, undo, time)
 
-		local lns = table.slice(self.lines, 1, line1 - 1)
-		local start = accumulateLen(lns)
-
-		local tsByte = start + col1 - 1
+		local tsByte = accumulateLen(self.lines, 1, line1 - 1) + col1 - 1
 
 		self.ts.tree:edit_s {
 			start_byte    = tsByte,

--- a/init.lua
+++ b/init.lua
@@ -243,7 +243,7 @@ function Highlight:tokenize_line(idx, state)
 	
 	return {
 		init_state = state,
-		state      = {},
+		state      = state,
 		text       = txt,
 		tokens     = toks
 	}


### PR DESCRIPTION
1. Fix issue where all lines after the edited line gets re-tokenised, because we return a new table for state instead of simply returning the one given in the params.
2. Refactor how we calculate the start byte for edits since the old way involved obtaining a slice of a table, which is not necessary.
3. Fix the oversight of nodes with predicates not being reported as changed when the predicate changes. We work around this by triggering re-tokenisation of all other lines the nodes on the changed line reside upon.
4. Temporary workaround to get source text due to ltreesitter giving rubbish values.