### PR TITLE
Meson build support of all dependencies

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -13,6 +13,10 @@ system.mkdir(config.dataDir)
 system.mkdir(config.parserLocation)
 
 appendPaths {
+	util.join {USERDIR .. PATHSEP .. 'tree-sitter', '?' .. util.soname},
+	util.join {USERDIR .. PATHSEP .. 'tree-sitter' .. PATHSEP .. 'parsers', 'libtree-sitter-?' .. util.soname},
+	util.join {DATADIR .. PATHSEP .. 'tree-sitter', '?' .. util.soname},
+	util.join {DATADIR .. PATHSEP .. 'tree-sitter' .. PATHSEP .. 'parsers', 'libtree-sitter-?' .. util.soname},
 	util.join {config.dataDir, '?' .. util.soname},
 	util.join {config.parserLocation, '?', 'libtree-sitter-?' .. util.soname},
 	util.join {config.parserLocation, '?', 'parser' .. util.soname},
@@ -184,7 +188,7 @@ end
 local oldTokenize = Highlight.tokenize_line
 function Highlight:tokenize_line(idx, state)
 	if not self.doc.treesit then return oldTokenize(self, idx, state) end
-	
+
 	local txt      = self.doc.lines[idx]
 	local row      = idx - 1
 	local toks     = {}
@@ -237,7 +241,7 @@ function Highlight:tokenize_line(idx, state)
 
 		i = i - 2
 	end
-	
+
 	return {
 		init_state = state,
 		state      = state,

--- a/init.lua
+++ b/init.lua
@@ -13,10 +13,10 @@ system.mkdir(config.dataDir)
 system.mkdir(config.parserLocation)
 
 appendPaths {
-	util.join {USERDIR .. PATHSEP .. 'tree-sitter', '?' .. util.soname},
-	util.join {USERDIR .. PATHSEP .. 'tree-sitter' .. PATHSEP .. 'parsers', 'libtree-sitter-?' .. util.soname},
-	util.join {DATADIR .. PATHSEP .. 'tree-sitter', '?' .. util.soname},
-	util.join {DATADIR .. PATHSEP .. 'tree-sitter' .. PATHSEP .. 'parsers', 'libtree-sitter-?' .. util.soname},
+	util.join {USERDIR, 'tree-sitter', '?' .. util.soname},
+	util.join {USERDIR, 'tree-sitter', 'parsers', 'libtree-sitter-?' .. util.soname},
+	util.join {DATADIR, 'tree-sitter', '?' .. util.soname},
+	util.join {DATADIR, 'tree-sitter', 'parsers', 'libtree-sitter-?' .. util.soname},
 	util.join {config.dataDir, '?' .. util.soname},
 	util.join {config.parserLocation, '?', 'libtree-sitter-?' .. util.soname},
 	util.join {config.parserLocation, '?', 'parser' .. util.soname},

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,41 @@
+project('Evergreen',
+    version : '2.0.0',
+    license : 'MIT',
+    meson_version : '>= 0.56'
+)
+
+data_dir = get_option('data_dir')
+
+subproject('ltreesitter', default_options: [
+    'data_dir='+data_dir,
+    'use_system_lua='+get_option('use_system_lua').to_string(),
+    'jit='+get_option('use_system_lua').to_string(),
+])
+
+subproject('tree-sitter-c', default_options: ['data_dir='+data_dir])
+subproject('tree-sitter-cpp', default_options: ['data_dir='+data_dir])
+subproject('tree-sitter-d', default_options: ['data_dir='+data_dir])
+subproject('tree-sitter-diff', default_options: ['data_dir='+data_dir])
+subproject('tree-sitter-go', default_options: ['data_dir='+data_dir])
+subproject('tree-sitter-go-mod', default_options: ['data_dir='+data_dir])
+subproject('tree-sitter-javascript', default_options: ['data_dir='+data_dir])
+subproject('tree-sitter-julia', default_options: ['data_dir='+data_dir])
+subproject('tree-sitter-lua', default_options: ['data_dir='+data_dir])
+subproject('tree-sitter-rust', default_options: ['data_dir='+data_dir])
+subproject('tree-sitter-zig', default_options: ['data_dir='+data_dir])
+
+evergreen_files = [
+    'config.lua', 'highlights.lua', 'init.lua', 'installer.lua',
+    'languages.lua', 'LICENSE', 'parser.lua', 'README.md', 'style.lua',
+    'util.lua'
+]
+
+foreach evergreen_file : evergreen_files
+    install_data(evergreen_file,
+        install_dir: join_paths(get_option('data_dir'), 'plugins' / 'evergreen')
+    )
+endforeach
+
+install_subdir('queries',
+    install_dir: join_paths(get_option('data_dir'), 'plugins' / 'evergreen')
+)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,3 @@
+option('data_dir', type : 'string', value : '/', description: 'Data directory of installation')
+option('use_system_lua', type : 'boolean', value : true, description: 'Prefer System Lua over the meson wrap')
+option('jit', type : 'boolean', value : true, description: 'Use luajit')

--- a/subprojects/ltreesitter.wrap
+++ b/subprojects/ltreesitter.wrap
@@ -1,0 +1,6 @@
+[wrap-git]
+url = https://github.com/euclidianAce/ltreesitter
+revision = head
+depth = 1
+patch_directory = ltreesitter
+clone-recursive = true

--- a/subprojects/lua.wrap
+++ b/subprojects/lua.wrap
@@ -1,0 +1,14 @@
+[wrap-file]
+directory = lua-5.4.6
+source_url = https://www.lua.org/ftp/lua-5.4.6.tar.gz
+source_filename = lua-5.4.6.tar.gz
+source_hash = 7d5ea1b9cb6aa0b59ca3dde1c6adcb57ef83a1ba8e5432c0ecd06bf439b3ad88
+patch_filename = lua_5.4.6-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/lua_5.4.6-2/get_patch
+patch_hash = a218f93461b1d9ba9367506f3198815f84ee25e2e4b50894679004aee9cb46f2
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/lua_5.4.6-2/lua-5.4.6.tar.gz
+wrapdb_version = 5.4.6-2
+
+[provide]
+lua-5.4 = lua_dep
+lua = lua_dep

--- a/subprojects/luajit.wrap
+++ b/subprojects/luajit.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = LuaJIT-97c75843c642d304a81f20576a8e3dda9097e8b8
+source_url = https://github.com/LuaJIT/LuaJIT/archive/97c75843c642d304a81f20576a8e3dda9097e8b8.zip
+source_filename = LuaJIT-97c75843c642d304a81f20576a8e3dda9097e8b8.zip
+source_hash = c13a6e143c09e16395b4196063fdee94ce0021e14ee373113656fccdd6319b72
+patch_directory = luajit
+
+[provide]
+luajit = luajit_dep

--- a/subprojects/packagefiles/ltreesitter/meson.build
+++ b/subprojects/packagefiles/ltreesitter/meson.build
@@ -1,0 +1,97 @@
+project('ltreesitter',
+    ['c'],
+    version : 'GIT',
+    license : 'MIT',
+    meson_version : '>= 0.56',
+    default_options : ['c_std=c11']
+)
+
+cc = meson.get_compiler('c')
+
+use_system_lua = get_option('use_system_lua')
+
+lua_jit_found = false
+if get_option('jit') and meson.get_compiler('c').get_id() != 'msvc'
+    if not use_system_lua
+        luajit_dep = subproject('luajit').get_variable('luajit_dep')
+    else
+        luajit_dep = dependency('luajit', required : false,
+            default_options: ['default_library=static']
+        )
+    endif
+
+    if luajit_dep.found()
+        lua_jit_found = true
+    endif
+endif
+
+if not use_system_lua and not lua_jit_found
+    lua_dep = subproject('lua',
+    default_options: default_fallback_options + [
+            'default_library=static',
+            'line_editing=disabled',
+            'interpreter=false'
+        ]
+    ).get_variable('lua_dep')
+elif not lua_jit_found
+    # Lua has no official .pc file
+    # so distros come up with their own names
+    lua_names = [
+        'lua5.4', # Debian
+        'lua-5.4', # FreeBSD
+        'lua',    # Fedora
+    ]
+
+    foreach lua : lua_names
+        last_lua = (lua == lua_names[-1] or get_option('wrap_mode') == 'forcefallback')
+        lua_dep = dependency(lua, fallback: last_lua ? ['lua', 'lua_dep'] : [], required : false,
+            version: '>= 5.4',
+            default_options: default_fallback_options + ['default_library=static', 'line_editing=false', 'interpreter=false']
+        )
+        if lua_dep.found()
+            break
+        endif
+
+        if last_lua
+            # If we could not find lua on the system and fallbacks are disabled
+            # try the compiler as a last ditch effort, since Lua has no official
+            # pkg-config support.
+            lua_dep = cc.find_library('lua', required : true)
+        endif
+    endforeach
+else
+    lua_dep = luajit_dep
+endif
+
+library_suffix = []
+
+# On macOS the default suffix is .dylib but we need .so
+if host_machine.system() == 'darwin'
+    library_suffix = 'so'
+endif
+
+ltreesitter = shared_library('ltreesitter',
+    [
+        'csrc/dynamiclib.c',
+        'csrc/ltreesitter.c',
+        'csrc/luautils.c',
+        'csrc/node.c',
+        'csrc/object.c',
+        'csrc/parser.c',
+        'csrc/query.c',
+        'csrc/query_cursor.c',
+        'csrc/tree.c',
+        'csrc/tree_cursor.c',
+        'csrc/types.c'
+    ],
+    name_prefix: '',
+    name_suffix: library_suffix,
+    include_directories: [include_directories('include')],
+    dependencies: [
+        lua_dep,
+        dependency('tree-sitter'),
+        cc.find_library('m', required: false)
+    ],
+    install_dir: join_paths(get_option('data_dir'), 'tree-sitter'),
+    install: true,
+)

--- a/subprojects/packagefiles/ltreesitter/meson_options.txt
+++ b/subprojects/packagefiles/ltreesitter/meson_options.txt
@@ -1,0 +1,3 @@
+option('data_dir', type : 'string', value : '/', description: 'Data directory of installation')
+option('use_system_lua', type : 'boolean', value : false, description: 'Prefer System Lua over the meson wrap')
+option('jit', type : 'boolean', value : true, description: 'Use luajit')

--- a/subprojects/packagefiles/luajit/meson.build
+++ b/subprojects/packagefiles/luajit/meson.build
@@ -1,0 +1,36 @@
+project('luajit', 'c', version: '2.1.0')
+
+make_command = find_program('make', required: true)
+
+build_command = [make_command, 'amalg']
+
+env = environment()
+
+if host_machine.system() == 'darwin'
+    build_command += 'MACOSX_DEPLOYMENT_TARGET=10.11'
+    if meson.is_cross_build()
+        env.set('TARGET_CFLAGS', '-arch arm64')
+        env.set('TARGET_LDFLAGS', '-arch arm64')
+    endif
+endif
+
+build_command += [
+    'CFLAGS=-fPIC',
+    'XCFLAGS=-DLUAJIT_ENABLE_LUA52COMPAT',
+    'BUILDMODE=static', '-l', '90', '-j'
+]
+
+run_command(build_command, check: true, env: env)
+
+cc = meson.get_compiler('c')
+
+luajit = cc.find_library('luajit',
+    dirs: [ meson.current_source_dir() + '/src'],
+    required: true,
+    static: true
+)
+
+luajit_dep = declare_dependency(
+    dependencies: luajit,
+    include_directories: include_directories('src')
+)

--- a/subprojects/packagefiles/tree-sitter-c/meson.build
+++ b/subprojects/packagefiles/tree-sitter-c/meson.build
@@ -1,0 +1,24 @@
+project('tree-sitter-c',
+    ['c'],
+    version : 'GIT',
+    license : 'MIT',
+    meson_version : '>= 0.56',
+    default_options : ['c_std=c11']
+)
+
+library_suffix = []
+
+# On macOS the default suffix is .dylib but we need .so
+if host_machine.system() == 'darwin'
+    library_suffix = 'so'
+endif
+
+shared_library('tree-sitter-c',
+    [
+        'src/parser.c'
+    ],
+    name_suffix: library_suffix,
+    include_directories: [include_directories('src')],
+    install_dir: join_paths(get_option('data_dir'), 'tree-sitter', 'parsers'),
+    install: true,
+)

--- a/subprojects/packagefiles/tree-sitter-c/meson_options.txt
+++ b/subprojects/packagefiles/tree-sitter-c/meson_options.txt
@@ -1,0 +1,1 @@
+option('data_dir', type : 'string', value : '/', description: 'Data directory of installation')

--- a/subprojects/packagefiles/tree-sitter-cpp/meson.build
+++ b/subprojects/packagefiles/tree-sitter-cpp/meson.build
@@ -1,0 +1,25 @@
+project('tree-sitter-cpp',
+    ['c'],
+    version : 'GIT',
+    license : 'MIT',
+    meson_version : '>= 0.56',
+    default_options : ['c_std=c11']
+)
+
+library_suffix = []
+
+# On macOS the default suffix is .dylib but we need .so
+if host_machine.system() == 'darwin'
+    library_suffix = 'so'
+endif
+
+shared_library('tree-sitter-cpp',
+    [
+        'src/parser.c',
+        'src/scanner.c'
+    ],
+    name_suffix: library_suffix,
+    include_directories: [include_directories('src')],
+    install_dir: join_paths(get_option('data_dir'), 'tree-sitter', 'parsers'),
+    install: true,
+)

--- a/subprojects/packagefiles/tree-sitter-cpp/meson_options.txt
+++ b/subprojects/packagefiles/tree-sitter-cpp/meson_options.txt
@@ -1,0 +1,1 @@
+option('data_dir', type : 'string', value : '/', description: 'Data directory of installation')

--- a/subprojects/packagefiles/tree-sitter-d/meson.build
+++ b/subprojects/packagefiles/tree-sitter-d/meson.build
@@ -1,0 +1,25 @@
+project('tree-sitter-d',
+    ['c', 'cpp'],
+    version : 'GIT',
+    license : 'MIT',
+    meson_version : '>= 0.56',
+    default_options : ['c_std=c11']
+)
+
+library_suffix = []
+
+# On macOS the default suffix is .dylib but we need .so
+if host_machine.system() == 'darwin'
+    library_suffix = 'so'
+endif
+
+shared_library('tree-sitter-d',
+    [
+        'src/parser.c',
+        'src/scanner.cc'
+    ],
+    name_suffix: library_suffix,
+    include_directories: [include_directories('src')],
+    install_dir: join_paths(get_option('data_dir'), 'tree-sitter', 'parsers'),
+    install: true,
+)

--- a/subprojects/packagefiles/tree-sitter-d/meson_options.txt
+++ b/subprojects/packagefiles/tree-sitter-d/meson_options.txt
@@ -1,0 +1,1 @@
+option('data_dir', type : 'string', value : '/', description: 'Data directory of installation')

--- a/subprojects/packagefiles/tree-sitter-d/src/tree_sitter/parser.h
+++ b/subprojects/packagefiles/tree-sitter-d/src/tree_sitter/parser.h
@@ -1,0 +1,224 @@
+#ifndef TREE_SITTER_PARSER_H_
+#define TREE_SITTER_PARSER_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define ts_builtin_sym_error ((TSSymbol)-1)
+#define ts_builtin_sym_end 0
+#define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
+
+typedef uint16_t TSStateId;
+
+#ifndef TREE_SITTER_API_H_
+typedef uint16_t TSSymbol;
+typedef uint16_t TSFieldId;
+typedef struct TSLanguage TSLanguage;
+#endif
+
+typedef struct {
+  TSFieldId field_id;
+  uint8_t child_index;
+  bool inherited;
+} TSFieldMapEntry;
+
+typedef struct {
+  uint16_t index;
+  uint16_t length;
+} TSFieldMapSlice;
+
+typedef struct {
+  bool visible;
+  bool named;
+  bool supertype;
+} TSSymbolMetadata;
+
+typedef struct TSLexer TSLexer;
+
+struct TSLexer {
+  int32_t lookahead;
+  TSSymbol result_symbol;
+  void (*advance)(TSLexer *, bool);
+  void (*mark_end)(TSLexer *);
+  uint32_t (*get_column)(TSLexer *);
+  bool (*is_at_included_range_start)(const TSLexer *);
+  bool (*eof)(const TSLexer *);
+};
+
+typedef enum {
+  TSParseActionTypeShift,
+  TSParseActionTypeReduce,
+  TSParseActionTypeAccept,
+  TSParseActionTypeRecover,
+} TSParseActionType;
+
+typedef union {
+  struct {
+    uint8_t type;
+    TSStateId state;
+    bool extra;
+    bool repetition;
+  } shift;
+  struct {
+    uint8_t type;
+    uint8_t child_count;
+    TSSymbol symbol;
+    int16_t dynamic_precedence;
+    uint16_t production_id;
+  } reduce;
+  uint8_t type;
+} TSParseAction;
+
+typedef struct {
+  uint16_t lex_state;
+  uint16_t external_lex_state;
+} TSLexMode;
+
+typedef union {
+  TSParseAction action;
+  struct {
+    uint8_t count;
+    bool reusable;
+  } entry;
+} TSParseActionEntry;
+
+struct TSLanguage {
+  uint32_t version;
+  uint32_t symbol_count;
+  uint32_t alias_count;
+  uint32_t token_count;
+  uint32_t external_token_count;
+  uint32_t state_count;
+  uint32_t large_state_count;
+  uint32_t production_id_count;
+  uint32_t field_count;
+  uint16_t max_alias_sequence_length;
+  const uint16_t *parse_table;
+  const uint16_t *small_parse_table;
+  const uint32_t *small_parse_table_map;
+  const TSParseActionEntry *parse_actions;
+  const char * const *symbol_names;
+  const char * const *field_names;
+  const TSFieldMapSlice *field_map_slices;
+  const TSFieldMapEntry *field_map_entries;
+  const TSSymbolMetadata *symbol_metadata;
+  const TSSymbol *public_symbol_map;
+  const uint16_t *alias_map;
+  const TSSymbol *alias_sequences;
+  const TSLexMode *lex_modes;
+  bool (*lex_fn)(TSLexer *, TSStateId);
+  bool (*keyword_lex_fn)(TSLexer *, TSStateId);
+  TSSymbol keyword_capture_token;
+  struct {
+    const bool *states;
+    const TSSymbol *symbol_map;
+    void *(*create)(void);
+    void (*destroy)(void *);
+    bool (*scan)(void *, TSLexer *, const bool *symbol_whitelist);
+    unsigned (*serialize)(void *, char *);
+    void (*deserialize)(void *, const char *, unsigned);
+  } external_scanner;
+  const TSStateId *primary_state_ids;
+};
+
+/*
+ *  Lexer Macros
+ */
+
+#define START_LEXER()           \
+  bool result = false;          \
+  bool skip = false;            \
+  bool eof = false;             \
+  int32_t lookahead;            \
+  goto start;                   \
+  next_state:                   \
+  lexer->advance(lexer, skip);  \
+  start:                        \
+  skip = false;                 \
+  lookahead = lexer->lookahead;
+
+#define ADVANCE(state_value) \
+  {                          \
+    state = state_value;     \
+    goto next_state;         \
+  }
+
+#define SKIP(state_value) \
+  {                       \
+    skip = true;          \
+    state = state_value;  \
+    goto next_state;      \
+  }
+
+#define ACCEPT_TOKEN(symbol_value)     \
+  result = true;                       \
+  lexer->result_symbol = symbol_value; \
+  lexer->mark_end(lexer);
+
+#define END_STATE() return result;
+
+/*
+ *  Parse Table Macros
+ */
+
+#define SMALL_STATE(id) id - LARGE_STATE_COUNT
+
+#define STATE(id) id
+
+#define ACTIONS(id) id
+
+#define SHIFT(state_value)            \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = state_value            \
+    }                                 \
+  }}
+
+#define SHIFT_REPEAT(state_value)     \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = state_value,           \
+      .repetition = true              \
+    }                                 \
+  }}
+
+#define SHIFT_EXTRA()                 \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .extra = true                   \
+    }                                 \
+  }}
+
+#define REDUCE(symbol_val, child_count_val, ...) \
+  {{                                             \
+    .reduce = {                                  \
+      .type = TSParseActionTypeReduce,           \
+      .symbol = symbol_val,                      \
+      .child_count = child_count_val,            \
+      __VA_ARGS__                                \
+    },                                           \
+  }}
+
+#define RECOVER()                    \
+  {{                                 \
+    .type = TSParseActionTypeRecover \
+  }}
+
+#define ACCEPT_INPUT()              \
+  {{                                \
+    .type = TSParseActionTypeAccept \
+  }}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TREE_SITTER_PARSER_H_

--- a/subprojects/packagefiles/tree-sitter-diff/meson.build
+++ b/subprojects/packagefiles/tree-sitter-diff/meson.build
@@ -1,0 +1,24 @@
+project('tree-sitter-diff',
+    ['c'],
+    version : 'GIT',
+    license : 'MIT',
+    meson_version : '>= 0.56',
+    default_options : ['c_std=c11']
+)
+
+library_suffix = []
+
+# On macOS the default suffix is .dylib but we need .so
+if host_machine.system() == 'darwin'
+    library_suffix = 'so'
+endif
+
+shared_library('tree-sitter-diff',
+    [
+        'src/parser.c'
+    ],
+    name_suffix: library_suffix,
+    include_directories: [include_directories('src')],
+    install_dir: join_paths(get_option('data_dir'), 'tree-sitter', 'parsers'),
+    install: true,
+)

--- a/subprojects/packagefiles/tree-sitter-diff/meson_options.txt
+++ b/subprojects/packagefiles/tree-sitter-diff/meson_options.txt
@@ -1,0 +1,1 @@
+option('data_dir', type : 'string', value : '/', description: 'Data directory of installation')

--- a/subprojects/packagefiles/tree-sitter-go-mod/meson.build
+++ b/subprojects/packagefiles/tree-sitter-go-mod/meson.build
@@ -1,0 +1,24 @@
+project('tree-sitter-go-mod',
+    ['c'],
+    version : 'GIT',
+    license : 'MIT',
+    meson_version : '>= 0.56',
+    default_options : ['c_std=c11']
+)
+
+library_suffix = []
+
+# On macOS the default suffix is .dylib but we need .so
+if host_machine.system() == 'darwin'
+    library_suffix = 'so'
+endif
+
+shared_library('tree-sitter-go-mod',
+    [
+        'src/parser.c'
+    ],
+    name_suffix: library_suffix,
+    include_directories: [include_directories('src')],
+    install_dir: join_paths(get_option('data_dir'), 'tree-sitter', 'parsers'),
+    install: true,
+)

--- a/subprojects/packagefiles/tree-sitter-go-mod/meson_options.txt
+++ b/subprojects/packagefiles/tree-sitter-go-mod/meson_options.txt
@@ -1,0 +1,1 @@
+option('data_dir', type : 'string', value : '/', description: 'Data directory of installation')

--- a/subprojects/packagefiles/tree-sitter-go/meson.build
+++ b/subprojects/packagefiles/tree-sitter-go/meson.build
@@ -1,0 +1,24 @@
+project('tree-sitter-go',
+    ['c'],
+    version : 'GIT',
+    license : 'MIT',
+    meson_version : '>= 0.56',
+    default_options : ['c_std=c11']
+)
+
+library_suffix = []
+
+# On macOS the default suffix is .dylib but we need .so
+if host_machine.system() == 'darwin'
+    library_suffix = 'so'
+endif
+
+shared_library('tree-sitter-go',
+    [
+        'src/parser.c'
+    ],
+    name_suffix: library_suffix,
+    include_directories: [include_directories('src')],
+    install_dir: join_paths(get_option('data_dir'), 'tree-sitter', 'parsers'),
+    install: true,
+)

--- a/subprojects/packagefiles/tree-sitter-go/meson_options.txt
+++ b/subprojects/packagefiles/tree-sitter-go/meson_options.txt
@@ -1,0 +1,1 @@
+option('data_dir', type : 'string', value : '/', description: 'Data directory of installation')

--- a/subprojects/packagefiles/tree-sitter-javascript/meson.build
+++ b/subprojects/packagefiles/tree-sitter-javascript/meson.build
@@ -1,0 +1,25 @@
+project('tree-sitter-javascript',
+    ['c'],
+    version : 'GIT',
+    license : 'MIT',
+    meson_version : '>= 0.56',
+    default_options : ['c_std=c11']
+)
+
+library_suffix = []
+
+# On macOS the default suffix is .dylib but we need .so
+if host_machine.system() == 'darwin'
+    library_suffix = 'so'
+endif
+
+shared_library('tree-sitter-javascript',
+    [
+        'src/parser.c',
+        'src/scanner.c'
+    ],
+    name_suffix: library_suffix,
+    include_directories: [include_directories('src')],
+    install_dir: join_paths(get_option('data_dir'), 'tree-sitter', 'parsers'),
+    install: true,
+)

--- a/subprojects/packagefiles/tree-sitter-javascript/meson_options.txt
+++ b/subprojects/packagefiles/tree-sitter-javascript/meson_options.txt
@@ -1,0 +1,1 @@
+option('data_dir', type : 'string', value : '/', description: 'Data directory of installation')

--- a/subprojects/packagefiles/tree-sitter-julia/meson.build
+++ b/subprojects/packagefiles/tree-sitter-julia/meson.build
@@ -1,0 +1,25 @@
+project('tree-sitter-julia',
+    ['c'],
+    version : 'GIT',
+    license : 'MIT',
+    meson_version : '>= 0.56',
+    default_options : ['c_std=c11']
+)
+
+library_suffix = []
+
+# On macOS the default suffix is .dylib but we need .so
+if host_machine.system() == 'darwin'
+    library_suffix = 'so'
+endif
+
+shared_library('tree-sitter-julia',
+    [
+        'src/parser.c',
+        'src/scanner.c'
+    ],
+    name_suffix: library_suffix,
+    include_directories: [include_directories('src')],
+    install_dir: join_paths(get_option('data_dir'), 'tree-sitter', 'parsers'),
+    install: true,
+)

--- a/subprojects/packagefiles/tree-sitter-julia/meson_options.txt
+++ b/subprojects/packagefiles/tree-sitter-julia/meson_options.txt
@@ -1,0 +1,1 @@
+option('data_dir', type : 'string', value : '/', description: 'Data directory of installation')

--- a/subprojects/packagefiles/tree-sitter-lua/meson.build
+++ b/subprojects/packagefiles/tree-sitter-lua/meson.build
@@ -1,0 +1,24 @@
+project('tree-sitter-lua',
+    ['c'],
+    version : 'GIT',
+    license : 'MIT',
+    meson_version : '>= 0.56',
+    default_options : ['c_std=c11']
+)
+
+library_suffix = []
+
+# On macOS the default suffix is .dylib but we need .so
+if host_machine.system() == 'darwin'
+    library_suffix = 'so'
+endif
+
+shared_library('tree-sitter-lua',
+    [
+        'src/parser.c', 'src/scanner.c'
+    ],
+    name_suffix: library_suffix,
+    include_directories: [include_directories('src')],
+    install_dir: join_paths(get_option('data_dir'), 'tree-sitter', 'parsers'),
+    install: true,
+)

--- a/subprojects/packagefiles/tree-sitter-lua/meson_options.txt
+++ b/subprojects/packagefiles/tree-sitter-lua/meson_options.txt
@@ -1,0 +1,1 @@
+option('data_dir', type : 'string', value : '/', description: 'Data directory of installation')

--- a/subprojects/packagefiles/tree-sitter-rust/meson.build
+++ b/subprojects/packagefiles/tree-sitter-rust/meson.build
@@ -1,0 +1,25 @@
+project('tree-sitter-rust',
+    ['c'],
+    version : 'GIT',
+    license : 'MIT',
+    meson_version : '>= 0.56',
+    default_options : ['c_std=c11']
+)
+
+library_suffix = []
+
+# On macOS the default suffix is .dylib but we need .so
+if host_machine.system() == 'darwin'
+    library_suffix = 'so'
+endif
+
+shared_library('tree-sitter-rust',
+    [
+        'src/parser.c',
+        'src/scanner.c'
+    ],
+    name_suffix: library_suffix,
+    include_directories: [include_directories('src')],
+    install_dir: join_paths(get_option('data_dir'), 'tree-sitter', 'parsers'),
+    install: true,
+)

--- a/subprojects/packagefiles/tree-sitter-rust/meson_options.txt
+++ b/subprojects/packagefiles/tree-sitter-rust/meson_options.txt
@@ -1,0 +1,1 @@
+option('data_dir', type : 'string', value : '/', description: 'Data directory of installation')

--- a/subprojects/packagefiles/tree-sitter-zig/meson.build
+++ b/subprojects/packagefiles/tree-sitter-zig/meson.build
@@ -1,0 +1,24 @@
+project('tree-sitter-zig',
+    ['c'],
+    version : 'GIT',
+    license : 'MIT',
+    meson_version : '>= 0.56',
+    default_options : ['c_std=c11']
+)
+
+library_suffix = []
+
+# On macOS the default suffix is .dylib but we need .so
+if host_machine.system() == 'darwin'
+    library_suffix = 'so'
+endif
+
+shared_library('tree-sitter-zig',
+    [
+        'src/parser.c'
+    ],
+    name_suffix: library_suffix,
+    include_directories: [include_directories('src')],
+    install_dir: join_paths(get_option('data_dir'), 'tree-sitter', 'parsers'),
+    install: true,
+)

--- a/subprojects/packagefiles/tree-sitter-zig/meson_options.txt
+++ b/subprojects/packagefiles/tree-sitter-zig/meson_options.txt
@@ -1,0 +1,1 @@
+option('data_dir', type : 'string', value : '/', description: 'Data directory of installation')

--- a/subprojects/packagefiles/tree-sitter/meson.build
+++ b/subprojects/packagefiles/tree-sitter/meson.build
@@ -1,0 +1,29 @@
+project('tree-sitter',
+    ['c'],
+    version : 'GIT',
+    license : 'MIT',
+    meson_version : '>= 0.56',
+    default_options : ['c_std=gnu99']
+)
+
+tree_sitter = static_library('tree-sitter',
+    [
+        'lib/src/alloc.c',
+        'lib/src/get_changed_ranges.c',
+        'lib/src/language.c',
+        'lib/src/lexer.c',
+        'lib/src/node.c',
+        'lib/src/parser.c',
+        'lib/src/query.c',
+        'lib/src/stack.c',
+        'lib/src/subtree.c',
+        'lib/src/tree.c',
+        'lib/src/tree_cursor.c',
+    ],
+    include_directories: [include_directories('lib/include')]
+)
+
+tree_sitter_dep = declare_dependency(
+    link_with: tree_sitter,
+    include_directories: include_directories('lib/include')
+)

--- a/subprojects/tree-sitter-c.wrap
+++ b/subprojects/tree-sitter-c.wrap
@@ -1,0 +1,5 @@
+[wrap-git]
+url = https://github.com/tree-sitter/tree-sitter-c
+revision = head
+depth = 1
+patch_directory = tree-sitter-c

--- a/subprojects/tree-sitter-cpp.wrap
+++ b/subprojects/tree-sitter-cpp.wrap
@@ -1,0 +1,5 @@
+[wrap-git]
+url = https://github.com/tree-sitter/tree-sitter-cpp
+revision = head
+depth = 1
+patch_directory = tree-sitter-cpp

--- a/subprojects/tree-sitter-d.wrap
+++ b/subprojects/tree-sitter-d.wrap
@@ -1,0 +1,5 @@
+[wrap-git]
+url = https://github.com/CyberShadow/tree-sitter-d
+revision = head
+depth = 1
+patch_directory = tree-sitter-d

--- a/subprojects/tree-sitter-diff.wrap
+++ b/subprojects/tree-sitter-diff.wrap
@@ -1,0 +1,5 @@
+[wrap-git]
+url = https://github.com/the-mikedavis/tree-sitter-diff
+revision = head
+depth = 1
+patch_directory = tree-sitter-diff

--- a/subprojects/tree-sitter-go-mod.wrap
+++ b/subprojects/tree-sitter-go-mod.wrap
@@ -1,0 +1,5 @@
+[wrap-git]
+url = https://github.com/camdencheek/tree-sitter-go-mod
+revision = head
+depth = 1
+patch_directory = tree-sitter-go-mod

--- a/subprojects/tree-sitter-go.wrap
+++ b/subprojects/tree-sitter-go.wrap
@@ -1,0 +1,5 @@
+[wrap-git]
+url = https://github.com/tree-sitter/tree-sitter-go
+revision = head
+depth = 1
+patch_directory = tree-sitter-go

--- a/subprojects/tree-sitter-javascript.wrap
+++ b/subprojects/tree-sitter-javascript.wrap
@@ -1,0 +1,5 @@
+[wrap-git]
+url = https://github.com/tree-sitter/tree-sitter-javascript
+revision = head
+depth = 1
+patch_directory = tree-sitter-javascript

--- a/subprojects/tree-sitter-julia.wrap
+++ b/subprojects/tree-sitter-julia.wrap
@@ -1,0 +1,5 @@
+[wrap-git]
+url = https://github.com/tree-sitter/tree-sitter-julia
+revision = head
+depth = 1
+patch_directory = tree-sitter-julia

--- a/subprojects/tree-sitter-lua.wrap
+++ b/subprojects/tree-sitter-lua.wrap
@@ -1,0 +1,5 @@
+[wrap-git]
+url = https://github.com/MunifTanjim/tree-sitter-lua
+revision = head
+depth = 1
+patch_directory = tree-sitter-lua

--- a/subprojects/tree-sitter-rust.wrap
+++ b/subprojects/tree-sitter-rust.wrap
@@ -1,0 +1,5 @@
+[wrap-git]
+url = https://github.com/tree-sitter/tree-sitter-rust
+revision = head
+depth = 1
+patch_directory = tree-sitter-rust

--- a/subprojects/tree-sitter-zig.wrap
+++ b/subprojects/tree-sitter-zig.wrap
@@ -1,0 +1,5 @@
+[wrap-git]
+url = https://github.com/maxxnino/tree-sitter-zig
+revision = head
+depth = 1
+patch_directory = tree-sitter-zig

--- a/subprojects/tree-sitter.wrap
+++ b/subprojects/tree-sitter.wrap
@@ -1,0 +1,8 @@
+[wrap-git]
+url = https://github.com/tree-sitter/tree-sitter
+revision = head
+depth = 1
+patch_directory = tree-sitter
+
+[provide]
+tree-sitter = tree_sitter_dep


### PR DESCRIPTION
I was planning on adding this plugin as part of the build system of [Pragtical](https://github.com/pragtical/pragtical) (as requested by some users), but first needed an easy way to build everything for easy testing and distribution. As title already says this PR adds meson support for easy building and installation of all the required libraries.

## Example:

```sh
meson setup build
meson compile -C build
DESTDIR=/home/user/.config/pragtical meson install -C build
```

The above commands will compile all supported tree-sitter parsers and install everything in the following structure:

```
.config/pragtical
├── plugins
│   └── evergreen
│       ├── config.lua
│       ├── highlights.lua
│       ├── init.lua
│       ├── installer.lua
│       ├── languages.lua
│       ├── LICENSE
│       ├── parser.lua
│       ├── queries
│       │   ├── c
│       │   │   └── highlights.scm
│       │   ├── cpp
│       │   │   └── highlights.scm
│       │   ├── d
│       │   │   └── highlights.scm
│       │   ├── diff
│       │   │   └── highlights.scm
│       │   ├── go
│       │   │   └── highlights.scm
│       │   ├── gomod
│       │   │   └── highlights.scm
│       │   ├── javascript
│       │   │   └── highlights.scm
│       │   ├── julia
│       │   │   └── highlights.scm
│       │   ├── lua
│       │   │   └── highlights.scm
│       │   ├── rust
│       │   │   └── highlights.scm
│       │   └── zig
│       │       └── highlights.scm
│       ├── README.md
│       ├── style.lua
│       └── util.lua
└── tree-sitter
    ├── ltreesitter.so
    └── parsers
        ├── libtree-sitter-cpp.so
        ├── libtree-sitter-c.so
        ├── libtree-sitter-diff.so
        ├── libtree-sitter-d.so
        ├── libtree-sitter-go-mod.so
        ├── libtree-sitter-go.so
        ├── libtree-sitter-javascript.so
        ├── libtree-sitter-julia.so
        ├── libtree-sitter-lua.so
        ├── libtree-sitter-rust.so
        └── libtree-sitter-zig.so
```

## Compiling for Distribution

For easy distribution, static compilation is supported since subprojects are provided for all the base required libraries. The compilation procedure would be the same as above with the only difference of forcing all fallbacks:

```sh
meson setup --wrap-mode=forcefallback build
meson compile -C build
```

These PR doesn't provides the CI building bits, that should be worked separately.

## Build Options

The following build options are provided for controlling the lua runtime to use:

```meson
option('use_system_lua', type : 'boolean', value : true, description: 'Prefer System Lua over the meson wrap')
option('jit', type : 'boolean', value : true, description: 'Use luajit')
```

These options can be used at `setup` time as follows:

```sh
meson setup -Duse_system_lua=false -Djit=false build
```
